### PR TITLE
Add Telegram bot skeleton with MongoDB service card workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # tg-inv
+
+Telegram bot for collecting inventory service cards using MongoDB.
+
+## Features
+- Admin can add service names with `/add`.
+- Users receive a random incomplete card and fill missing fields.
+- Input text is parsed into card fields via a simple LLM placeholder.
+- Users confirm parsed fields before saving to the database.
+
+## Running
+1. Install requirements: `pip install -r requirements.txt`.
+2. Set environment variables:
+   - `TELEGRAM_TOKEN` – token of your Telegram bot.
+   - `MONGO_URL` – MongoDB connection string.
+   - `DB_NAME` – database name (default `tg_inv`).
+3. Start the bot: `python -m bot.bot`.
+
+## Testing
+Run tests with:
+```bash
+pytest
+```

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,0 +1,127 @@
+import logging
+from typing import Dict
+
+from telegram import (
+    Update,
+    ReplyKeyboardMarkup,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+)
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    CallbackQueryHandler,
+    filters,
+)
+
+from .config import TELEGRAM_TOKEN, REQUIRED_FIELDS
+from .service_repository import (
+    add_services,
+    get_random_incomplete,
+    update_service,
+)
+from .llm import parse_fields
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Здравствуйте! Нажмите 'Заполнить карточку', чтобы начать.",
+        reply_markup=ReplyKeyboardMarkup([["Заполнить карточку"]], resize_keyboard=True),
+    )
+
+
+def render_card(card: Dict) -> str:
+    lines = [f"Карточка: {card['name']}"]
+    fields = card.get("fields", {})
+    for f in REQUIRED_FIELDS:
+        val = fields.get(f) or "<пусто>"
+        lines.append(f"{f}: {val}")
+    return "\n".join(lines)
+
+
+async def add(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text("Использование: /add name1 name2 ...")
+        return
+    count = add_services(context.args)
+    await update.message.reply_text(f"Добавлено {count} карточек")
+
+
+async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    text = update.message.text
+    if text == "Заполнить карточку":
+        card = get_random_incomplete()
+        if not card:
+            await update.message.reply_text("Все карточки заполнены!")
+            return
+        context.user_data["card"] = card
+        await update.message.reply_text(render_card(card))
+        await update.message.reply_text(
+            "Введите данные для недостающих полей в формате key=value",
+        )
+        context.user_data["awaiting"] = True
+    elif context.user_data.get("awaiting"):
+        fields = parse_fields(text)
+        if not fields:
+            await update.message.reply_text("Не удалось распознать данные, попробуйте ещё раз")
+            return
+        context.user_data["parsed_fields"] = fields
+        summary = "\n".join(f"{k}: {v}" for k, v in fields.items())
+        await update.message.reply_text(
+            f"Я понял так:\n{summary}\nВерно?",
+            reply_markup=InlineKeyboardMarkup(
+                [
+                    [
+                        InlineKeyboardButton("Да", callback_data="yes"),
+                        InlineKeyboardButton("Нет", callback_data="no"),
+                    ]
+                ]
+            ),
+        )
+        context.user_data["awaiting"] = False
+    else:
+        await update.message.reply_text(
+            "Не понимаю. Нажмите 'Заполнить карточку' чтобы начать.",
+            reply_markup=ReplyKeyboardMarkup([["Заполнить карточку"]], resize_keyboard=True),
+        )
+
+
+async def handle_confirmation(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    if query.data == "yes":
+        card = context.user_data.get("card")
+        fields = context.user_data.get("parsed_fields", {})
+        if card and fields:
+            update_service(card["_id"], fields)
+            await query.edit_message_text("Сохранено")
+        else:
+            await query.edit_message_text("Нет данных для сохранения")
+    else:
+        await query.edit_message_text("Введите данные ещё раз")
+        context.user_data["awaiting"] = True
+        return
+    # After handling, propose next card
+    await query.message.reply_text(
+        "Заполнить следующую?",
+        reply_markup=ReplyKeyboardMarkup([["Заполнить карточку"]], resize_keyboard=True),
+    )
+
+
+def main() -> None:
+    app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
+
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("add", add))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+    app.add_handler(CallbackQueryHandler(handle_confirmation))
+
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,8 @@
+import os
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN", "CHANGE_ME")
+MONGO_URL = os.getenv("MONGO_URL", "mongodb://localhost:27017")
+DB_NAME = os.getenv("DB_NAME", "tg_inv")
+
+# Fields required to consider a service card complete
+REQUIRED_FIELDS = ["type", "owner", "description"]

--- a/bot/db.py
+++ b/bot/db.py
@@ -1,0 +1,7 @@
+from pymongo import MongoClient
+
+from .config import MONGO_URL, DB_NAME
+
+client = MongoClient(MONGO_URL)
+db = client[DB_NAME]
+services = db.services

--- a/bot/llm.py
+++ b/bot/llm.py
@@ -1,0 +1,20 @@
+import re
+from typing import Dict
+
+
+def parse_fields(text: str) -> Dict[str, str]:
+    """A very small placeholder for an LLM that extracts key/value pairs.
+
+    Expected format: "key=value" separated by commas or newlines.
+    """
+    parts = re.split(r"[\n,]+", text)
+    data: Dict[str, str] = {}
+    for part in parts:
+        if "=" in part:
+            k, v = part.split("=", 1)
+        elif ":" in part:
+            k, v = part.split(":", 1)
+        else:
+            continue
+        data[k.strip()] = v.strip()
+    return data

--- a/bot/service_repository.py
+++ b/bot/service_repository.py
@@ -1,0 +1,42 @@
+import random
+from typing import Dict, List, Optional
+
+from .config import REQUIRED_FIELDS
+
+
+def add_services(names: List[str], collection=None) -> int:
+    """Add service names to the collection as empty cards.
+
+    Returns number of new services created.
+    """
+    created = 0
+    if collection is None:
+        from .db import services as collection
+
+    for name in names:
+        if collection.count_documents({"name": name}) == 0:
+            collection.insert_one({"name": name, "fields": {}})
+            created += 1
+    return created
+
+
+def is_complete(service: Dict) -> bool:
+    fields = service.get("fields", {})
+    return all(fields.get(f) for f in REQUIRED_FIELDS)
+
+
+def get_random_incomplete(collection=None) -> Optional[Dict]:
+    if collection is None:
+        from .db import services as collection
+    incomplete = list(collection.find({}))
+    incomplete = [s for s in incomplete if not is_complete(s)]
+    if not incomplete:
+        return None
+    return random.choice(incomplete)
+
+
+def update_service(service_id, fields: Dict[str, str], collection=None) -> None:
+    """Update fields of a service card by its identifier."""
+    if collection is None:
+        from .db import services as collection
+    collection.update_one({"_id": service_id}, {"$set": {f"fields.{k}": v for k, v in fields.items()}})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot>=20.0
+pymongo>=4.0

--- a/tests/test_service_repository.py
+++ b/tests/test_service_repository.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict, List
+import uuid
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from bot import service_repository as repo
+from bot.config import REQUIRED_FIELDS
+
+
+class InMemoryCollection:
+    """Minimal in-memory stand-in for a MongoDB collection."""
+
+    def __init__(self):
+        self.data: List[Dict[str, Any]] = []
+
+    def insert_one(self, doc: Dict[str, Any]) -> None:
+        doc = dict(doc)
+        doc.setdefault("_id", uuid.uuid4().hex)
+        self.data.append(doc)
+
+    def find(self, filter: Dict[str, Any] | None = None):
+        if not filter:
+            return list(self.data)
+        return [d for d in self.data if all(d.get(k) == v for k, v in filter.items())]
+
+    def find_one(self, filter: Dict[str, Any]):
+        results = self.find(filter)
+        return results[0] if results else None
+
+    def count_documents(self, filter: Dict[str, Any]):
+        return len(self.find(filter))
+
+    def update_one(self, filter: Dict[str, Any], update: Dict[str, Any]):
+        doc = self.find_one(filter)
+        if not doc:
+            return
+        for k, v in update.get("$set", {}).items():
+            parts = k.split(".")
+            target = doc
+            for part in parts[:-1]:
+                target = target.setdefault(part, {})
+            target[parts[-1]] = v
+
+
+def test_add_and_complete_flow():
+    col = InMemoryCollection()
+    added = repo.add_services(["s1", "s2"], collection=col)
+    assert added == 2
+    added = repo.add_services(["s1"], collection=col)
+    assert added == 0
+
+    card = repo.get_random_incomplete(collection=col)
+    assert card is not None
+    service_id = card["_id"]
+
+    fields = {f: f"value_{f}" for f in REQUIRED_FIELDS}
+    repo.update_service(service_id, fields, collection=col)
+
+    card = col.find_one({"_id": service_id})
+    assert repo.is_complete(card)


### PR DESCRIPTION
## Summary
- implement service card repository with MongoDB and placeholder LLM parser
- add Telegram bot that guides users through completing random service cards
- provide in-memory tests for repository logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6d87607c83218100838cb970fd45
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Telegram bot skeleton for managing service cards with MongoDB, including repository logic and tests.
> 
>   - **Telegram Bot**:
>     - Adds `bot.py` to implement a Telegram bot for managing service cards.
>     - Supports `/add` command to add service names and guides users to fill incomplete cards.
>     - Uses `parse_fields()` from `llm.py` to parse user input.
>   - **Service Repository**:
>     - Implements `add_services()`, `get_random_incomplete()`, and `update_service()` in `service_repository.py` for managing service cards in MongoDB.
>     - Uses `REQUIRED_FIELDS` from `config.py` to determine card completeness.
>   - **Testing**:
>     - Adds `test_service_repository.py` with in-memory tests for repository functions.
>     - Uses `InMemoryCollection` to simulate MongoDB operations.
>   - **Configuration**:
>     - Adds `config.py` for environment variables and required fields.
>     - Adds `db.py` to set up MongoDB client and services collection.
>   - **Misc**:
>     - Updates `README.md` with setup and usage instructions.
>     - Adds `requirements.txt` for dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2Ftg-inv&utm_source=github&utm_medium=referral)<sup> for f7b4eb1088660aa5df9a23742816d39290493077. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->